### PR TITLE
now that's quality Soup

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,5 +1,4 @@
 import discord, config, random, time, traceback, datetime, logging
-from logging import handlers
 from datetime import datetime
 from typing import List, Optional
 from discord.ext import commands
@@ -15,13 +14,6 @@ def error_template(e):
     embed = discord.Embed(title=f"An error occurred!", colour=discord.Colour.red())
     embed.add_field(name="Error", value=f"{e}")
     return embed
-
-def dt_to_timestamp(dt: datetime, f):
-    formats = ["d", "D", "t", "T", "f", "F", "R"]
-    if f not in formats:
-        return str(round(time.mktime(dt.timetuple())))
-    else:
-        return f"<t:{round(time.mktime(dt.timetuple()))}:{f}>"
 
 @bot.event
 async def on_ready():
@@ -43,8 +35,8 @@ async def on_message(message: discord.Message):
 @bot.event
 async def on_member_update(before: discord.Member, after: discord.Member):
     if before.timed_out_until == None and after.timed_out_until != None:
-        to_until_a = dt_to_timestamp(after.timed_out_until, "R")
-        to_until_b = dt_to_timestamp(after.timed_out_until, "f")
+        to_until_a = nitro.dt_to_timestamp(after.timed_out_until, "R")
+        to_until_b = nitro.dt_to_timestamp(after.timed_out_until, "f")
 
         embed = discord.Embed(title="Member timed out", colour=discord.Colour.brand_red())
         embed.add_field(name="Timed out until", value=f"{to_until_a} ({to_until_b})")
@@ -118,16 +110,17 @@ async def programme(interaction: discord.Interaction,
         if listing['isToday']: 
             for off, i in enumerate(listing['items']):
                 epochnow = int(datetime.now().timestamp())
+                starttime, endtime = i['time'][0], i['time'][1]
                 # if the time right now is higher than the start time 
                 # *and* the endtime is higher than the start... it's live.
-                if epochnow > i['time'][0] and i['time'][1] > epochnow:
+                if epochnow > starttime and endtime > epochnow:
                    todaylive = off 
         # sorts out every item with it's formatted date
         for off, i in enumerate(listing['items']):
             if todaylive and off == todaylive:
-                items += f"<t:{i['time'][0]}:t> - **{i['title']} (LIVE)**\n"
+                items += f"<t:{starttime}:t> - **{i['title']} (LIVE)**\n"
             else:
-                items += f"<t:{i['time'][0]}:t> - {i['title']}\n"
+                items += f"<t:{starttime}:t> - {i['title']}\n"
         # adds the items field after being parsed as a single-str
         e.add_field(name=f"Page {page} (times are based on your system clock):", value=items)
         await interaction.response.send_message(embed=e, ephemeral=False)

--- a/main.py
+++ b/main.py
@@ -113,10 +113,11 @@ async def programme(interaction: discord.Interaction,
                 starttime, endtime = i['time'][0], i['time'][1]
                 # if the time right now is higher than the start time 
                 # *and* the endtime is higher than the start... it's live.
-                if epochnow > starttime and endtime > epochnow:
+                if epochnow > i['time'][0] and i['time'][1] > epochnow:
                    todaylive = off 
         # sorts out every item with it's formatted date
         for off, i in enumerate(listing['items']):
+            starttime = i['time'][0]
             if todaylive and off == todaylive:
                 items += f"<t:{starttime}:t> - **{i['title']} (LIVE)**\n"
             else:

--- a/modules/nitro.py
+++ b/modules/nitro.py
@@ -108,8 +108,8 @@ async def get_schedule(db, sid, date=None, page=0):
                                 except:
                                     title = i['ancestors_titles']['episode']
                             # converts to unix
-                            starttime = dt_to_timestamp(datetime.fromisoformat(i['published_time']['start']))
-                            endtime = dt_to_timestamp(datetime.fromisoformat(i['published_time']['end']))
+                            starttime = dt_to_timestamp(datetime.fromisoformat(i['published_time']['start']), "z")
+                            endtime = dt_to_timestamp(datetime.fromisoformat(i['published_time']['end']), "z")
                             listing['items'].append({
                                 "title": title['title'],
                                 "pid": i['pid'],

--- a/modules/nitro.py
+++ b/modules/nitro.py
@@ -1,4 +1,12 @@
-import config, aiohttp, re, datetime
+import config, aiohttp, re 
+from datetime import datetime
+
+def dt_to_timestamp(dt: datetime, f):
+    formats = ["d", "D", "t", "T", "f", "F", "R"]
+    if f not in formats:
+        return int(dt.timestamp())
+    else:
+        return f"<t:{int(dt.timestamp())}:{f}>"
 
 async def verify_date(date):
     try:
@@ -12,7 +20,7 @@ async def verify_date(date):
     # year, month and day to ensure they are with the correct length 
     # and do not contain strings or any special contents.
     if isinstance(dsplit[0], str) and len(dsplit[0]) == 4 and isinstance(dsplit[1], str) and len(dsplit[1]) == 2 and isinstance(dsplit[2], str) and len(dsplit[2]) == 2:
-        curdate = datetime.datetime.now()
+        curdate = datetime.now()
         # check if it's not higher than current year and if date is not not older than two years.
         if year > curdate.year or year < curdate.year - 2:
             return "Year higher, or older than accepted"
@@ -28,7 +36,7 @@ async def verify_date(date):
         if day > 31 or month == 2 and day > 28:
             return "incorrectDay"
         # else, return the correct datetime.
-        fetchdate = datetime.datetime(int(dsplit[0]), int(dsplit[1]), int(dsplit[2]))
+        fetchdate = datetime(int(dsplit[0]), int(dsplit[1]), int(dsplit[2]))
         return fetchdate
     else:
         return "Incorrect Date"
@@ -45,10 +53,10 @@ async def resolve_sid(sid, db):
 
 
 async def get_schedule(db, sid, date=None, page=0):
-    if not isinstance(date, datetime.datetime):
+    if not isinstance(date, datetime):
         # goes under a check to see if the inputted values are correct
         if not date: 
-            parsed_date = datetime.datetime.now() # if date is none, give current day
+            parsed_date = datetime.now() # if date is none, give current day
         else:
             parsed_date = await verify_date(date) 
     # raises an exception if the function returns a string/error. 
@@ -81,7 +89,7 @@ async def get_schedule(db, sid, date=None, page=0):
                             "items": [] 
                         }
                         # checks if schedule is from today
-                        if listing['date'] == datetime.datetime.now().strftime("%Y-%m-%d"):
+                        if listing['date'] == datetime.now().strftime("%Y-%m-%d"):
                             listing['isToday'] = True
                         # gets every item available in the first search query
                         try:
@@ -100,8 +108,8 @@ async def get_schedule(db, sid, date=None, page=0):
                                 except:
                                     title = i['ancestors_titles']['episode']
                             # converts to unix
-                            starttime = int(datetime.datetime.fromisoformat(i['published_time']['start']).timestamp())
-                            endtime = int(datetime.datetime.fromisoformat(i['published_time']['end']).timestamp())
+                            starttime = dt_to_timestamp(datetime.fromisoformat(i['published_time']['start']))
+                            endtime = dt_to_timestamp(datetime.fromisoformat(i['published_time']['end']))
                             listing['items'].append({
                                 "title": title['title'],
                                 "pid": i['pid'],


### PR DESCRIPTION
- uses `datetime.datetime` import on nitro, cleaning things out
- uses `int(datetime.timestamp())` for a much cleaner conversion of dt_to_timestamp, alongside moving that function to the "nitro" due to it also being useful for such purpose + being a "less clamped" form of isolating all datetime-utility functions (unless they are highly specific for another command module, that is)
- removes `logging.handlers` import as it was used for a testing purpose but never actually implemented
